### PR TITLE
Bump versions of ubuntu

### DIFF
--- a/start_iso_to_ovf.sh
+++ b/start_iso_to_ovf.sh
@@ -8,11 +8,11 @@ set -e
 # Configuration
 
 # Precise
-ubuntu_version_full="12.04.4"
+ubuntu_version_full="12.04.5"
 ubuntu_version_short="12.04"
 ubuntu_version_codename="precise"
 # Trusty
-#ubuntu_version_full="14.04.1"
+#ubuntu_version_full="14.04.2"
 #ubuntu_version_short="14.04"
 #ubuntu_version_codename="trusty"
 


### PR DESCRIPTION
The `http://releases.ubuntu.com/x.y/SHA1SUMS` files only contains the checksums of the latest versions of Ubuntu.

The checksums of `12.04.4` and `14.04.1` are no longer available.

http://releases.ubuntu.com/12.04/SHA1SUMS 

```
b8c2e054b2a398cf02f268fcc1966b29c6dc007e *ubuntu-12.04.5-alternate-amd64.iso
505f7a1c27953b93cb75915559a59e1e1a59ba9f *ubuntu-12.04.5-alternate-i386.iso
aa2802735c552d36e222e09fb64971d558142713 *ubuntu-12.04.5-desktop-amd64.iso
3d9b4e7d6267e05b9e3d6e39c33f59db8e4ef6a4 *ubuntu-12.04.5-desktop-i386.iso
7540ace2d6cdee264432f5ed987236d32edef798 *ubuntu-12.04.5-server-amd64.iso
a34c224b7fe72a2f5c768be5afee5c53817743fd *ubuntu-12.04.5-server-i386.iso
c15a5960500593b5b2b0d62832367b218a95d20b *wubi.exe
```

http://releases.ubuntu.com/14.04/SHA1SUMS

```
394fe6a12ded5a812d9ca0a9f6ce75ef83fb667e *ubuntu-14.04.2-desktop-amd64.iso
f6ce137030af96c40ab4d2544430f674e8c747c1 *ubuntu-14.04.2-desktop-i386.iso
3bfa6eac84d527380d0cc52db9092cde127f161e *ubuntu-14.04.2-server-amd64.iso
80b1a915f42cc298855bd4e298f5bfbeb61d800e *ubuntu-14.04.2-server-i386.iso
bfc1ff3446b8cb49b6481372a2edf1c3861ba727 *wubi.exe
```
